### PR TITLE
created a simple DSL for arbitrary table creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,41 @@ ui.div(
 console.log(ui.toString())
 ```
 
+## Layout DSL
+
+cliui exposes a simple layout DSL:
+
+If you create a single `ui.row`, passing a string rather than an
+object:
+
+* `\n`: characters will be interpreted as new rows.
+* '\t': characters will be interpreted as new columns.
+* ' ': characters will be interpreted as padding.
+
+**as an example...**
+
+```js
+var ui = require('./')({
+  width: 60
+})
+
+ui.div(
+  'Usage: node ./bin/foo.js\n' +
+  '  <regex>\t  provide a regex\n' +
+  '  <glob>\t  provide a glob\t [required]'
+)
+
+console.log(ui.toString())
+```
+
+**will output:**
+
+```shell
+Usage: node ./bin/foo.js
+  <regex>  provide a regex
+  <glob>   provide a glob          [required]
+```
+
 ## Methods
 
 ```js

--- a/test/cliui.js
+++ b/test/cliui.js
@@ -295,4 +295,55 @@ describe('cliui', function () {
       ui.toString().split('\n').should.eql(expected)
     })
   })
+
+  describe('layoutDSL', function () {
+    it('turns tab into multiple columns', function () {
+      var ui = cliui({
+        width: 60
+      })
+
+      ui.div(
+        '  <regex>  \tmy awesome regex\n  <my second thing>  \tanother row\t  a third column'
+      )
+
+      var expected = [
+       '  <regex>            my awesome regex',
+       '  <my second thing>  another row          a third column'
+      ]
+
+      ui.toString().split('\n').should.eql(expected)
+    })
+
+    it('turns newline into multiple rows', function () {
+      var ui = cliui({
+        width: 40
+      })
+
+      ui.div(
+        'Usage: $0\n  <regex>\t  my awesome regex\n  <glob>\t  my awesome glob\t  [required]'
+      )
+      var expected = [
+       'Usage: $0',
+       '  <regex>  my awesome regex',
+       '  <glob>   my awesome     [required]',
+       '           glob'
+      ]
+
+      ui.toString().split('\n').should.eql(expected)
+    })
+
+    it('does not apply DSL if wrap is false', function () {
+      var ui = cliui({
+        width: 40,
+        wrap: false
+      })
+
+      ui.div(
+        'Usage: $0\ttwo\tthree'
+      )
+
+      ui.toString().should.eql('Usage: $0\ttwo\tthree')
+    })
+
+  })
 })


### PR DESCRIPTION
cliui will now make an attempt to turn ` `, `\t`, and `\n` into a pretty-printed table. This is useful for libraries that consume cliui like yargs.