### PR TITLE
span functionality was not appropriately handling ansi escape codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "dependencies": {
-    "center-align": "^0.1.1",
-    "right-align": "^0.1.1",
     "string-width": "^1.0.1",
     "wrap-ansi": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cliui",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "easily create complex multi-column command-line-interfaces",
   "main": "index.js",
   "scripts": {

--- a/test/cliui.js
+++ b/test/cliui.js
@@ -296,6 +296,29 @@ describe('cliui', function () {
 
       ui.toString().split('\n').should.eql(expected)
     })
+
+    it('appends to prior line appropriately when strings contain ansi escape codes', function () {
+      var ui = cliui({
+        width: 40
+      })
+
+      ui.span(
+        {text: chalk.green('i am a string that will be wrapped'), width: 30}
+      )
+
+      ui.div(
+        {text: chalk.blue(' [required] [default: 99]'), align: 'right'}
+      )
+
+      var expected = [
+        'i am a string that will be',
+        'wrapped         [required] [default: 99]'
+      ]
+
+      ui.toString().split('\n').map(function (l) {
+        return stripAnsi(l)
+      }).should.eql(expected)
+    })
   })
 
   describe('layoutDSL', function () {


### PR DESCRIPTION
Using `wrap-ansi` and `string-width`, `cliui` now lets you layout complex multi-column command line UIs with ansi escape codes \o/

@sindresorhus, @dthree