### PR TITLE
Ignore ANSI escape codes when measuring padding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var stringWidth = require('string-width')
+var stripAnsi = require('strip-ansi')
 var wrap = require('wrap-ansi')
 var align = {
   right: alignRight,
@@ -67,9 +68,11 @@ UI.prototype._applyLayoutDSL = function (str) {
   rows.forEach(function (row) {
     var columns = row.split('\t')
     _this.div.apply(_this, columns.map(function (r, i) {
+      // measure padding without ansi escape codes
+      var rNoAnsi = stripAnsi(r)
       return {
         text: r.trim(),
-        padding: [0, r.match(/\s*$/)[0].length, 0, r.match(/^\s*/)[0].length],
+        padding: [0, rNoAnsi.match(/\s*$/)[0].length, 0, rNoAnsi.match(/^\s*/)[0].length],
         width: (i === 0 && columns.length > 1) ? leftColumnWidth : undefined
       }
     }))

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ UI.prototype.toString = function () {
 
 UI.prototype.rowToString = function (row, lines) {
   var _this = this
-  var paddingLeft
+  var padding
   var rrows = this._rasterize(row)
   var str = ''
   var ts
@@ -140,15 +140,15 @@ UI.prototype.rowToString = function (row, lines) {
       }
 
       // add left/right padding and print string.
-      paddingLeft = (row[c].padding || [0, 0, 0, 0])[left]
-      if (paddingLeft) str += new Array(row[c].padding[left] + 1).join(' ')
+      padding = row[c].padding || [0, 0, 0, 0]
+      if (padding[left]) str += new Array(padding[left] + 1).join(' ')
       str += ts
-      if (row[c].padding && row[c].padding[right]) str += new Array(row[c].padding[right] + 1).join(' ')
+      if (padding[right]) str += new Array(padding[right] + 1).join(' ')
 
       // if prior row is span, try to render the
       // current row on the prior line.
       if (r === 0 && lines.length > 0) {
-        str = _this._renderInline(str, lines[lines.length - 1], paddingLeft)
+        str = _this._renderInline(str, lines[lines.length - 1])
       }
     })
 
@@ -164,7 +164,7 @@ UI.prototype.rowToString = function (row, lines) {
 
 // if the full 'source' can render in
 // the target line, do so.
-UI.prototype._renderInline = function (source, previousLine, paddingLeft) {
+UI.prototype._renderInline = function (source, previousLine) {
   var leadingWhitespace = source.match(/^ */)[0].length
   var target = previousLine.text
   var targetTextWidth = stringWidth(target.trimRight())

--- a/index.js
+++ b/index.js
@@ -68,11 +68,9 @@ UI.prototype._applyLayoutDSL = function (str) {
   rows.forEach(function (row) {
     var columns = row.split('\t')
     _this.div.apply(_this, columns.map(function (r, i) {
-      // measure padding without ansi escape codes
-      var rNoAnsi = stripAnsi(r)
       return {
         text: r.trim(),
-        padding: [0, rNoAnsi.match(/\s*$/)[0].length, 0, rNoAnsi.match(/^\s*/)[0].length],
+        padding: _this._measurePadding(r),
         width: (i === 0 && columns.length > 1) ? leftColumnWidth : undefined
       }
     }))
@@ -83,8 +81,15 @@ UI.prototype._applyLayoutDSL = function (str) {
 
 UI.prototype._colFromString = function (str) {
   return {
-    text: str
+    text: str,
+    padding: this._measurePadding(str)
   }
+}
+
+UI.prototype._measurePadding = function (str) {
+  // measure padding without ansi escape codes
+  var noAnsi = stripAnsi(str)
+  return [0, noAnsi.match(/\s*$/)[0].length, 0, noAnsi.match(/^\s*/)[0].length]
 }
 
 UI.prototype.toString = function () {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "license": "ISC",
   "dependencies": {
     "string-width": "^1.0.1",
+    "strip-ansi": "^3.0.0",
     "wrap-ansi": "^1.0.0"
   },
   "devDependencies": {
@@ -52,7 +53,6 @@
     "coveralls": "^2.11.4",
     "mocha": "^2.3.3",
     "nyc": "^3.2.2",
-    "standard": "^5.3.1",
-    "strip-ansi": "^3.0.0"
+    "standard": "^5.3.1"
   }
 }

--- a/test/cliui.js
+++ b/test/cliui.js
@@ -211,6 +211,22 @@ describe('cliui', function () {
 
       ui.toString().split('\n').should.eql(expected)
     })
+
+    it('preserves leading whitespace as padding', function () {
+      var ui = cliui()
+
+      ui.div('     LEADING WHITESPACE')
+      ui.div('\u001b[34m     with ansi\u001b[39m')
+
+      var expected = [
+        '     LEADING WHITESPACE',
+        '     with ansi'
+      ]
+
+      ui.toString().split('\n').map(function (l) {
+        return stripAnsi(l)
+      }).should.eql(expected)
+    })
   })
 
   describe('wrap', function () {

--- a/test/cliui.js
+++ b/test/cliui.js
@@ -366,12 +366,35 @@ describe('cliui', function () {
         '  <regex>\t  ' + chalk.red('my awesome regex') + '\t  [regex]\n  ' + chalk.blue('<glob>') + '\t  my awesome glob\t  [required]'
       )
 
-      chalk
       var expected = [
         '  <regex>  my awesome     [regex]',
         '           regex',
         '  <glob>   my awesome     [required]',
         '           glob'
+      ]
+
+      ui.toString().split('\n').map(function (l) {
+        return stripAnsi(l)
+      }).should.eql(expected)
+    })
+
+    it('ignores ansi escape codes when measuring padding', function () {
+      var ui = cliui({
+        width: 25
+      })
+
+      // using figlet font 'Shadow' rendering of text 'true' here
+      ui.div(
+        chalk.blue('  |                      \n  __|   __|  |   |   _ \\ \n  |    |     |   |   __/ \n \\__| _|    \\__,_| \\___| \n                         ')
+      )
+
+      // relevant part is first line - leading whitespace should be preserved as left padding
+      var expected = [
+        '  |',
+        '  __|   __|  |   |   _ \\',
+        '  |    |     |   |   __/',
+        ' \\__| _|    \\__,_| \\___|',
+        '                         '
       ]
 
       ui.toString().split('\n').map(function (l) {


### PR DESCRIPTION
Resolves [yargonaut issue 7](https://github.com/nexdrew/yargonaut/issues/7).

The problem is that padding was being measured in `_applyLayoutDSL()` without accounting for ANSI escape codes. So if a string like this:

```js
'\u001b[34m     LEADING WHITESPACE\n     HERE TOO          \u001b[39m'
```

was given to cliui, it would result in padding: `[ 0, 0, 0, 0 ]` and `[ 0, 0, 0, 5 ]` respectively, since the first line begins with an escape code and the last line ends with an escape code (no padding detected). The expected padding should be `[ 0, 0, 0, 5 ]` and `[ 0, 10, 0, 5 ]` respectively, since escape codes should be ignored.

If escape codes are not ignored, then whitespace is lost when the padding is applied later in `rowToString()`.